### PR TITLE
Fix typo: "Requirments" → "Requirements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A set of contracts that are similar to Arbitrum [gov-action-contracts](https://github.com/ArbitrumFoundation/governance/tree/main/src/gov-action-contracts), but are designed to be used with Orbit chains looking to migrate to Celestia DA
 
-## Requirments
+## Requirements
 
 [yarn](https://classic.yarnpkg.com/lang/en/docs/install/) and [foundry](https://book.getfoundry.sh/getting-started/installation) are required to run the scripts
 


### PR DESCRIPTION
"Requirments" → "Requirements"